### PR TITLE
Point setup-go's cache at each module's go.sum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           # gofmt is module-independent; any module's toolchain will do.
           go-version-file: kanban/go.mod
+          cache-dependency-path: kanban/go.sum
       - name: gofmt
         run: |
           unformatted=$(gofmt -l .)
@@ -57,6 +58,9 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: ${{ matrix.module }}/go.mod
+          # Without this, setup-go looks for a go.sum at the repo root, finds
+          # none, and silently disables the module cache for every job.
+          cache-dependency-path: ${{ matrix.module }}/go.sum
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
@@ -86,6 +90,9 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: ${{ matrix.module }}/go.mod
+          # Without this, setup-go looks for a go.sum at the repo root, finds
+          # none, and silently disables the module cache for every job.
+          cache-dependency-path: ${{ matrix.module }}/go.sum
       - name: Build
         run: go build ./...
         working-directory: ${{ matrix.module }}


### PR DESCRIPTION
## Summary

Every job in the first CI run logged:

```
##[warning]Restore cache failed: Dependencies file is not found in
/home/runner/work/estoria-examples/estoria-examples. Supported file pattern: go.sum
```

19 of 19 jobs, every run. `actions/setup-go` enables its module cache by default but looks for `go.sum` at the repo root — and this repo doesn't have one, because every example is its own module. So the cache was silently off everywhere and each job re-downloaded its dependencies from scratch.

Naming the module's `go.sum` fixes it. Nothing about what the jobs *do* changes.

Missed this when adding CI in #4: the warning doesn't fail a job, and the checks were green.