### PR TITLE
Add Railway service config for the containerized examples

### DIFF
--- a/chess/README.md
+++ b/chess/README.md
@@ -125,6 +125,11 @@ docker build -t estoria-chess .
 docker run -p 8084:8084 estoria-chess
 ```
 
+On Railway, add a service pointed at this repository and set its **Root
+Directory** to `/chess` — without it the build runs from the repository root,
+which has no module and no Dockerfile. `railway.toml` in this folder covers
+the rest (builder, health check, restart policy).
+
 It listens on `$PORT` when the platform sets one, so it drops straight onto
 Railway, Fly, or Cloud Run. The database lives at `/data` — mount a volume there
 to keep games across deploys, or don't, and every deploy starts fresh.

--- a/chess/railway.toml
+++ b/chess/railway.toml
@@ -1,0 +1,18 @@
+# Railway service configuration for the chess server.
+#
+# One thing here cannot be set from a config file: the service's **Root
+# Directory**, which must be set to `/chess` in the Railway dashboard
+# (Settings -> Source). Without it Railway builds from the repository root,
+# finds no go.mod and no Dockerfile, and fails with "could not determine how
+# to build the app" — this repo has no root module by design, since every
+# example is its own.
+#
+# With the root directory set, the Dockerfile in this folder is used, and
+# $PORT is injected by the platform.
+
+[build]
+builder = "DOCKERFILE"
+
+[deploy]
+healthcheckPath = "/"
+restartPolicyType = "ON_FAILURE"

--- a/kanban/README.md
+++ b/kanban/README.md
@@ -117,6 +117,11 @@ docker build -t estoria-kanban .
 docker run -p 8080:8080 estoria-kanban
 ```
 
+On Railway, add a service pointed at this repository and set its **Root
+Directory** to `/kanban` — without it the build runs from the repository root,
+which has no module and no Dockerfile. `railway.toml` in this folder covers
+the rest (builder, health check, restart policy).
+
 It listens on `$PORT` when the platform sets one, so it drops straight onto
 Railway, Fly, or Cloud Run. The database lives at `/data` — mount a volume there
 to keep the board across deploys, or don't, and every deploy starts fresh.

--- a/kanban/railway.toml
+++ b/kanban/railway.toml
@@ -1,0 +1,18 @@
+# Railway service configuration for the kanban board.
+#
+# One thing here cannot be set from a config file: the service's **Root
+# Directory**, which must be set to `/kanban` in the Railway dashboard
+# (Settings -> Source). Without it Railway builds from the repository root,
+# finds no go.mod and no Dockerfile, and fails with "could not determine how
+# to build the app" — this repo has no root module by design, since every
+# example is its own.
+#
+# With the root directory set, the Dockerfile in this folder is used, and
+# $PORT is injected by the platform.
+
+[build]
+builder = "DOCKERFILE"
+
+[deploy]
+healthcheckPath = "/"
+restartPolicyType = "ON_FAILURE"

--- a/orders/README.md
+++ b/orders/README.md
@@ -148,6 +148,11 @@ docker build -t estoria-orders .
 docker run -p 8082:8082 -e DATABASE_URL=postgres://... estoria-orders
 ```
 
+On Railway, add a service pointed at this repository and set its **Root
+Directory** to `/orders` — without it the build runs from the repository root,
+which has no module and no Dockerfile. `railway.toml` in this folder covers
+the rest (builder, health check, restart policy).
+
 It listens on `$PORT` and reads its DSN from `$DATABASE_URL` when they are set,
 so it drops straight onto Railway, Fly, or Cloud Run alongside a managed
 Postgres.

--- a/orders/railway.toml
+++ b/orders/railway.toml
@@ -1,0 +1,18 @@
+# Railway service configuration for the order service.
+#
+# One thing here cannot be set from a config file: the service's **Root
+# Directory**, which must be set to `/orders` in the Railway dashboard
+# (Settings -> Source). Without it Railway builds from the repository root,
+# finds no go.mod and no Dockerfile, and fails with "could not determine how
+# to build the app" — this repo has no root module by design, since every
+# example is its own.
+#
+# With the root directory set, the Dockerfile in this folder is used, and
+# $PORT is injected by the platform.
+
+[build]
+builder = "DOCKERFILE"
+
+[deploy]
+healthcheckPath = "/"
+restartPolicyType = "ON_FAILURE"


### PR DESCRIPTION
## Summary

A Railway service left at its defaults builds from the repository root, which in this repo has no module and no Dockerfile — every example is its own module by design. The result is a build failure before Railway ever reaches a Dockerfile:

```
Railpack 0.33.0
⚠ Script start.sh not found
✗ Railpack could not determine how to build the app.
```

The fix is the service's **Root Directory** setting (`/kanban`, `/chess`, `/orders`), which is Railway's documented pattern for an [isolated monorepo](https://docs.railway.com/guides/monorepo) — several unrelated apps in one repository, each service pulling only its own folder.

That setting has no config-as-code equivalent, so it can only live in the dashboard. What this PR does is make sure nobody has to rediscover that: each app now carries a `railway.toml` whose header comment states the requirement, next to the settings that *can* be declared — the Dockerfile builder, a health check on `/`, and an `ON_FAILURE` restart policy. Each README's deploy section says the same thing.

## Why not one bundled image

Worth recording, since it was the alternative considered. Serving all four apps from a single service behind path prefixes (`/kanban`, `/chess`, …) would need either a supervisor process plus a reverse proxy in one container, or the four `package main`s merged into one module — and the latter gives up the property that makes this repo useful, that any example can be copied out and run on its own.

It would also break the frontends. Every app's client calls absolute paths:

```js
fetch("/api/board")
new EventSource("/api/watch")
```

Under a path prefix those resolve to the wrong service, so bundling means either rewriting all four frontends to be prefix-aware or having a proxy rewrite responses. Both put hosting concerns into example code whose job is to demonstrate event sourcing. Four services and one setting each costs nothing by comparison.

Subdomain routing per app would avoid the prefix problem, but that's a DNS choice, not a reason to bundle the images.