### PR TITLE
Drop the VOLUME instruction Railway rejects

### DIFF
--- a/chess/Dockerfile
+++ b/chess/Dockerfile
@@ -28,12 +28,14 @@ COPY --from=build --chown=65532:65532 /data /data
 USER nonroot:nonroot
 
 # Informational only. The app listens on $PORT when the platform sets one
-# (Railway, Fly, Cloud Run, ...), falling back to :8080.
-EXPOSE 8080
+# (Railway, Fly, Cloud Run, ...), falling back to :8084.
+EXPOSE 8084
 
-# Mount a volume here to keep games across deploys; without one the container
-# starts from an empty lobby every time.
-VOLUME ["/data"]
+# The database lives in /data. There is deliberately no VOLUME instruction:
+# Railway rejects it ("docker VOLUME ... is not supported, use Railway Volumes"),
+# and it buys nothing here — `docker run -v name:/data` and a Railway Volume
+# mounted at /data both work without it. With no volume at all the container
+# starts from an empty lobby every time, which is what the hosted demo wants.
 
 # The default command is the hosted-demo configuration: the lobby is cleared on
 # the hour, writes are rate limited per client IP, and live connections are capped.

--- a/chess/README.md
+++ b/chess/README.md
@@ -131,8 +131,9 @@ which has no module and no Dockerfile. `railway.toml` in this folder covers
 the rest (builder, health check, restart policy).
 
 It listens on `$PORT` when the platform sets one, so it drops straight onto
-Railway, Fly, or Cloud Run. The database lives at `/data` — mount a volume there
-to keep games across deploys, or don't, and every deploy starts fresh.
+Railway, Fly, or Cloud Run. The database lives at `/data`; mount something there
+(`docker run -v`, or a Railway Volume) to keep games across deploys, or don't,
+and every deploy starts fresh.
 
 Four flags exist only for public hosting, and are off unless passed:
 

--- a/kanban/Dockerfile
+++ b/kanban/Dockerfile
@@ -31,9 +31,11 @@ USER nonroot:nonroot
 # (Railway, Fly, Cloud Run, ...), falling back to :8080.
 EXPOSE 8080
 
-# Mount a volume here to keep the board across deploys; without one the
-# container starts from a freshly seeded board every time.
-VOLUME ["/data"]
+# The database lives in /data. There is deliberately no VOLUME instruction:
+# Railway rejects it ("docker VOLUME ... is not supported, use Railway Volumes"),
+# and it buys nothing here — `docker run -v name:/data` and a Railway Volume
+# mounted at /data both work without it. With no volume at all the container
+# starts from a freshly seeded board every time, which is what the hosted demo wants.
 
 # The default command is the hosted-demo configuration: the board resets on the
 # hour, writes are rate limited per client IP, and live connections are capped.

--- a/kanban/README.md
+++ b/kanban/README.md
@@ -123,8 +123,9 @@ which has no module and no Dockerfile. `railway.toml` in this folder covers
 the rest (builder, health check, restart policy).
 
 It listens on `$PORT` when the platform sets one, so it drops straight onto
-Railway, Fly, or Cloud Run. The database lives at `/data` — mount a volume there
-to keep the board across deploys, or don't, and every deploy starts fresh.
+Railway, Fly, or Cloud Run. The database lives at `/data`; mount something there
+(`docker run -v`, or a Railway Volume) to keep the board across deploys, or
+don't, and every deploy starts fresh.
 
 Four flags exist only for public hosting, and are off unless passed:
 


### PR DESCRIPTION
## Summary

With the Root Directory fix in, the chess service got as far as building its Dockerfile and then failed:

```
dockerfile invalid: docker VOLUME at Line 36 is not supported, use Railway Volumes
```

Railway rejects `VOLUME` outright. Removing it costs nothing, because the instruction was never doing the work its comment implied:

- `/data` is created in the build stage and copied into the final image with nonroot ownership, so the app can write there whether or not `VOLUME` is declared.
- `docker run -v name:/data` still persists locally, and a Railway Volume mounted at `/data` still persists there.
- What `VOLUME` *did* add was an anonymous volume per `docker run` — for an ephemeral demo, that's litter, not a feature.

The comment in its place says all of that, so nobody adds it back.

Both images were rebuilt and exercised: chess creates a game and records a move into a database under `/data`, with no `VOLUME` instruction anywhere.

Also fixes chess's `EXPOSE`, which still said `8080` — left over from when its Dockerfile was adapted from kanban's. Informational only, but wrong is wrong.

Only kanban and chess were affected; orders keeps its state in Postgres and never had a `VOLUME`.