### PR TITLE
Reject the nil UUID instead of 500ing on it

### DIFF
--- a/chess/demo_test.go
+++ b/chess/demo_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -290,5 +291,44 @@ func TestRunResets(t *testing.T) {
 	case <-watcher:
 		t.Error("the scheduler kept resetting after its context was cancelled")
 	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+// TestPathGameID covers the three shapes a client can put in the {id} segment.
+// The nil UUID is the interesting one: it parses, so it reaches estoria, which
+// rejects it — and that surfaced as a 500 for what is plainly bad input.
+func TestPathGameID(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServer(t)
+	handler := srv.routes()
+
+	for _, tc := range []struct {
+		name string
+		id   string
+		want int
+	}{
+		{"malformed", "not-a-uuid", http.StatusBadRequest},
+		{"nil UUID", "00000000-0000-0000-0000-000000000000", http.StatusBadRequest},
+		{"well-formed but unknown", "83f07308-a33c-41ec-85f5-72d7afd3d73b", http.StatusNotFound},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			for _, target := range []string{
+				"GET /api/games/" + tc.id,
+				"POST /api/games/" + tc.id + "/move",
+			} {
+				method, path, _ := strings.Cut(target, " ")
+				rec := httptest.NewRecorder()
+				req := httptest.NewRequest(method, path, strings.NewReader(`{"baseVersion":1,"uci":"e2e4"}`))
+				req.Header.Set("Content-Type", "application/json")
+				handler.ServeHTTP(rec, req)
+
+				if rec.Code != tc.want {
+					t.Errorf("%s = %d, want %d (body: %s)", target, rec.Code, tc.want, rec.Body.String())
+				}
+			}
+		})
 	}
 }

--- a/chess/server.go
+++ b/chess/server.go
@@ -507,10 +507,14 @@ func (s *server) handleWatch(w http.ResponseWriter, r *http.Request) {
 }
 
 // pathGameID parses the {id} path segment as a game UUID, writing a 400 when
-// it is malformed.
+// it is malformed or nil.
+//
+// The nil UUID parses fine but is not a usable aggregate ID — estoria rejects
+// it downstream with "aggregate ID is nil", which would surface to the caller
+// as a 500 for what is plainly bad input.
 func pathGameID(w http.ResponseWriter, r *http.Request) (uuid.UUID, bool) {
 	id, err := uuid.FromString(r.PathValue("id"))
-	if err != nil {
+	if err != nil || id.IsNil() {
 		writeError(w, http.StatusBadRequest, "invalid game ID")
 		return uuid.Nil, false
 	}

--- a/orders/demo_test.go
+++ b/orders/demo_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -333,5 +334,42 @@ func TestHubCapacity(t *testing.T) {
 	h.unsubscribe(first)
 	if _, ok := h.subscribe(); !ok {
 		t.Error("a slot was not freed when a client disconnected")
+	}
+}
+
+// TestPathOrderID covers the {id} segment without needing a database: every
+// case is rejected before the handler touches a store, which is the point —
+// the nil UUID used to reach estoria and come back as a 500.
+func TestPathOrderID(t *testing.T) {
+	t.Parallel()
+
+	handler := (&server{}).routes()
+
+	for _, tc := range []struct {
+		name string
+		id   string
+		want int
+	}{
+		{"malformed", "not-a-uuid", http.StatusBadRequest},
+		{"nil UUID", "00000000-0000-0000-0000-000000000000", http.StatusBadRequest},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			for _, target := range []string{
+				"GET /api/orders/" + tc.id,
+				"POST /api/orders/" + tc.id + "/pay",
+			} {
+				method, path, _ := strings.Cut(target, " ")
+				rec := httptest.NewRecorder()
+				req := httptest.NewRequest(method, path, strings.NewReader(`{"baseVersion":1}`))
+				req.Header.Set("Content-Type", "application/json")
+				handler.ServeHTTP(rec, req)
+
+				if rec.Code != tc.want {
+					t.Errorf("%s = %d, want %d (body: %s)", target, rec.Code, tc.want, rec.Body.String())
+				}
+			}
+		})
 	}
 }

--- a/orders/server.go
+++ b/orders/server.go
@@ -136,9 +136,8 @@ func (s *server) handleCreateOrder(w http.ResponseWriter, r *http.Request) {
 func (s *server) handleGetOrder(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	id, err := uuid.FromString(r.PathValue("id"))
-	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid order ID")
+	id, ok := pathOrderID(w, r)
+	if !ok {
 		return
 	}
 
@@ -182,9 +181,8 @@ func (s *server) runCommand(w http.ResponseWriter, r *http.Request, baseVersion 
 
 	ctx := r.Context()
 
-	id, err := uuid.FromString(r.PathValue("id"))
-	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid order ID")
+	id, ok := pathOrderID(w, r)
+	if !ok {
 		return
 	}
 
@@ -462,6 +460,21 @@ func (s *server) handleWatch(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+}
+
+// pathOrderID parses the {id} path segment as an order UUID, writing a 400
+// when it is malformed or nil.
+//
+// The nil UUID parses fine but is not a usable aggregate ID — estoria rejects
+// it downstream with "aggregate ID is nil", which would surface to the caller
+// as a 500 for what is plainly bad input.
+func pathOrderID(w http.ResponseWriter, r *http.Request) (uuid.UUID, bool) {
+	id, err := uuid.FromString(r.PathValue("id"))
+	if err != nil || id.IsNil() {
+		writeError(w, http.StatusBadRequest, "invalid order ID")
+		return uuid.Nil, false
+	}
+	return id, true
 }
 
 func (s *server) writeLoadError(w http.ResponseWriter, err error) {


### PR DESCRIPTION
## Summary

Found by probing the newly-live chess deployment rather than by reading code:

```
POST /api/games/00000000-0000-0000-0000-000000000000/move
-> 500 {"error":"aggregate ID is nil"}
```

The nil UUID parses cleanly, so it passed the malformed-input check and reached estoria, which rejects it — turning a bad request into an internal error. Everything on either side of that case was already correct:

| Path segment | Before | After |
| --- | --- | --- |
| `not-a-uuid` | 400 | 400 |
| `00000000-0000-0000-0000-000000000000` | **500** | 400 |
| well-formed, no such game | 404 | 404 |

`chess`'s `pathGameID` gains the check. `orders` had the same parse copy-pasted into two handlers, so it gets the same helper — removing the duplication along with the bug.

- **fleet** is unaffected: it validates the ID against its device registry, so the nil UUID 404s like any other unknown device.
- **inspector** is unaffected: it reads streams and never loads an aggregate.

## Tests

`chess` exercises all three shapes through the real router. `orders` builds its handler from a zero-value `server` deliberately — every one of these is rejected before a store is touched, so the test needs no Postgres and runs in CI with everything else.

## Also from the live probe

Two things worth recording from poking at the deployed app, neither needing a change:

- **The rate limiter is not forgeable behind Railway.** Two never-before-seen forged `X-Forwarded-For` values landed in the *same* bucket as an unforged request — Railway overwrites the header, so `-trust-proxy` keys on the real client. Worth knowing, because if the leftmost entry had been client-controlled, the limiter would have been decorative: anyone could rotate identities per request.
- **SSE survives the edge.** `/api/watch` streams through Railway's proxy without buffering — the browser's "live" pill is genuine.