### PR TITLE
Declare watch paths so services stop redeploying each other

### DIFF
--- a/chess/railway.toml
+++ b/chess/railway.toml
@@ -13,6 +13,11 @@
 [build]
 builder = "DOCKERFILE"
 
+# Gitignore-style, relative to the repository root: only changes under this
+# example redeploy this service. Without it, every merge to main redeploys
+# every service in the project, since they all watch the same repo.
+watchPatterns = ["/chess/**"]
+
 [deploy]
 healthcheckPath = "/"
 restartPolicyType = "ON_FAILURE"

--- a/kanban/railway.toml
+++ b/kanban/railway.toml
@@ -13,6 +13,11 @@
 [build]
 builder = "DOCKERFILE"
 
+# Gitignore-style, relative to the repository root: only changes under this
+# example redeploy this service. Without it, every merge to main redeploys
+# every service in the project, since they all watch the same repo.
+watchPatterns = ["/kanban/**"]
+
 [deploy]
 healthcheckPath = "/"
 restartPolicyType = "ON_FAILURE"

--- a/orders/railway.toml
+++ b/orders/railway.toml
@@ -13,6 +13,11 @@
 [build]
 builder = "DOCKERFILE"
 
+# Gitignore-style, relative to the repository root: only changes under this
+# example redeploy this service. Without it, every merge to main redeploys
+# every service in the project, since they all watch the same repo.
+watchPatterns = ["/orders/**"]
+
 [deploy]
 healthcheckPath = "/"
 restartPolicyType = "ON_FAILURE"


### PR DESCRIPTION
## Summary

Every service in the Railway project watches the same repository, so without watch paths a merge to `main` redeploys all of them — three builds and three restarts for a change to one example.

Root Directory controls which files a service *builds from*; watch paths control which changes *trigger* a build. They're separate settings, and only the second one stops the cross-triggering.

Pattern shape confirmed against the dashboard rather than guessed: gitignore-style, relative to the repository root.

```toml
watchPatterns = ["/orders/**"]
```

Matches what's already configured by hand, so this changes nothing operationally — it just means the next person who adds an example gets it by copying the folder, and the config survives a project being recreated from scratch.