### PR TITLE
Update the applications to estoria v0.8.0 and contrib v0.8.0

### DIFF
--- a/chess/go.mod
+++ b/chess/go.mod
@@ -3,8 +3,8 @@ module github.com/go-estoria/estoria-examples/chess
 go 1.26.2
 
 require (
-	github.com/go-estoria/estoria v0.7.0
-	github.com/go-estoria/estoria-contrib v0.7.0
+	github.com/go-estoria/estoria v0.8.0
+	github.com/go-estoria/estoria-contrib v0.8.0
 	github.com/gofrs/uuid/v5 v5.4.0
 	github.com/notnil/chess v1.10.0
 	golang.org/x/time v0.15.0

--- a/chess/go.sum
+++ b/chess/go.sum
@@ -1,10 +1,10 @@
 github.com/ajstarks/svgo v0.0.0-20200320125537-f189e35d30ca/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/go-estoria/estoria v0.7.0 h1:6VZjt2oWbvmLm55DSJPpGcaDyrLGXE9iP6uRvXfOIb0=
-github.com/go-estoria/estoria v0.7.0/go.mod h1:w/1pwY/YU9M4WV+HdL2vpYVAhVINFwaVf1nSPnebNJQ=
-github.com/go-estoria/estoria-contrib v0.7.0 h1:nlvMUNXmP9mhJCcs5kbK90n3wkGkyF6VlKG4ljNDiQY=
-github.com/go-estoria/estoria-contrib v0.7.0/go.mod h1:ZKek1dXoVAPJlcSh2kjYm0bPy1F7LBxtchQ63g4XJJQ=
+github.com/go-estoria/estoria v0.8.0 h1:vEadMNigE+stOQsvWBEpk/JdFgiJpg1uJMdlyGdCnwE=
+github.com/go-estoria/estoria v0.8.0/go.mod h1:w/1pwY/YU9M4WV+HdL2vpYVAhVINFwaVf1nSPnebNJQ=
+github.com/go-estoria/estoria-contrib v0.8.0 h1:iPI9jKLpjodrcTk4Tr1YEakw0b1S5PC6BbwoNtBml/g=
+github.com/go-estoria/estoria-contrib v0.8.0/go.mod h1:buwC8y+PbBsffvosOe00D2h5pGqaX0RqTNVr+aTGrDQ=
 github.com/gofrs/uuid/v5 v5.4.0 h1:EfbpCTjqMuGyq5ZJwxqzn3Cbr2d0rUZU7v5ycAk/e/0=
 github.com/gofrs/uuid/v5 v5.4.0/go.mod h1:CDOjlDMVAtN56jqyRUZh58JT31Tiw7/oQyEXZV+9bD8=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=

--- a/fleet/device_test.go
+++ b/fleet/device_test.go
@@ -206,7 +206,10 @@ func TestSnapshotRoundTrip(t *testing.T) {
 
 	// the event-stream snapshot store works over any event store, including
 	// the in-memory one used here
-	snapStore := streamsnapshots.New(eventStore)
+	snapStore, err := streamsnapshots.New(eventStore)
+	if err != nil {
+		t.Fatal(err)
+	}
 	const snapshotEvery = 25
 	snapshotting, err := aggregatestore.NewSnapshottingStore(
 		plain, snapStore, snapshotstore.EventCountSnapshotPolicy{N: snapshotEvery})

--- a/fleet/go.mod
+++ b/fleet/go.mod
@@ -4,8 +4,8 @@ go 1.26.2
 
 require (
 	github.com/allegro/bigcache/v3 v3.1.0
-	github.com/go-estoria/estoria v0.7.0
-	github.com/go-estoria/estoria-contrib v0.7.0
+	github.com/go-estoria/estoria v0.8.0
+	github.com/go-estoria/estoria-contrib v0.8.0
 	github.com/gofrs/uuid/v5 v5.4.0
 	modernc.org/sqlite v1.54.0
 )

--- a/fleet/go.sum
+++ b/fleet/go.sum
@@ -2,10 +2,10 @@ github.com/allegro/bigcache/v3 v3.1.0 h1:H2Vp8VOvxcrB91o86fUSVJFqeuz8kpyyB02eH3b
 github.com/allegro/bigcache/v3 v3.1.0/go.mod h1:aPyh7jEvrog9zAwx5N7+JUQX5dZTSGpxF1LAR4dr35I=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/go-estoria/estoria v0.7.0 h1:6VZjt2oWbvmLm55DSJPpGcaDyrLGXE9iP6uRvXfOIb0=
-github.com/go-estoria/estoria v0.7.0/go.mod h1:w/1pwY/YU9M4WV+HdL2vpYVAhVINFwaVf1nSPnebNJQ=
-github.com/go-estoria/estoria-contrib v0.7.0 h1:nlvMUNXmP9mhJCcs5kbK90n3wkGkyF6VlKG4ljNDiQY=
-github.com/go-estoria/estoria-contrib v0.7.0/go.mod h1:ZKek1dXoVAPJlcSh2kjYm0bPy1F7LBxtchQ63g4XJJQ=
+github.com/go-estoria/estoria v0.8.0 h1:vEadMNigE+stOQsvWBEpk/JdFgiJpg1uJMdlyGdCnwE=
+github.com/go-estoria/estoria v0.8.0/go.mod h1:w/1pwY/YU9M4WV+HdL2vpYVAhVINFwaVf1nSPnebNJQ=
+github.com/go-estoria/estoria-contrib v0.8.0 h1:iPI9jKLpjodrcTk4Tr1YEakw0b1S5PC6BbwoNtBml/g=
+github.com/go-estoria/estoria-contrib v0.8.0/go.mod h1:buwC8y+PbBsffvosOe00D2h5pGqaX0RqTNVr+aTGrDQ=
 github.com/gofrs/uuid/v5 v5.4.0 h1:EfbpCTjqMuGyq5ZJwxqzn3Cbr2d0rUZU7v5ycAk/e/0=
 github.com/gofrs/uuid/v5 v5.4.0/go.mod h1:CDOjlDMVAtN56jqyRUZh58JT31Tiw7/oQyEXZV+9bD8=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=

--- a/fleet/main.go
+++ b/fleet/main.go
@@ -116,7 +116,11 @@ func run(ctx context.Context, addr, dbPath string, devices int, snapshotEvery in
 	//    in the same SQLite database — no separate snapshot storage needed.
 	//    This layer is also the benchmark's "snapshot" path (snapshotting
 	//    without caching).
-	snapStore := streamsnapshots.New(eventStore)
+	snapStore, err := streamsnapshots.New(eventStore)
+	if err != nil {
+		return fmt.Errorf("creating snapshot store: %w", err)
+	}
+
 	snapshotting, err := aggregatestore.NewSnapshottingStore(
 		eventSourced,
 		snapStore,

--- a/inspector/go.mod
+++ b/inspector/go.mod
@@ -3,8 +3,8 @@ module github.com/go-estoria/estoria-examples/inspector
 go 1.26.2
 
 require (
-	github.com/go-estoria/estoria v0.7.0
-	github.com/go-estoria/estoria-contrib v0.7.0
+	github.com/go-estoria/estoria v0.8.0
+	github.com/go-estoria/estoria-contrib v0.8.0
 	github.com/gofrs/uuid/v5 v5.4.0
 	github.com/jackc/pgx/v5 v5.10.0
 	modernc.org/sqlite v1.54.0

--- a/inspector/go.sum
+++ b/inspector/go.sum
@@ -33,10 +33,10 @@ github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/
 github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/go-estoria/estoria v0.7.0 h1:6VZjt2oWbvmLm55DSJPpGcaDyrLGXE9iP6uRvXfOIb0=
-github.com/go-estoria/estoria v0.7.0/go.mod h1:w/1pwY/YU9M4WV+HdL2vpYVAhVINFwaVf1nSPnebNJQ=
-github.com/go-estoria/estoria-contrib v0.7.0 h1:nlvMUNXmP9mhJCcs5kbK90n3wkGkyF6VlKG4ljNDiQY=
-github.com/go-estoria/estoria-contrib v0.7.0/go.mod h1:ZKek1dXoVAPJlcSh2kjYm0bPy1F7LBxtchQ63g4XJJQ=
+github.com/go-estoria/estoria v0.8.0 h1:vEadMNigE+stOQsvWBEpk/JdFgiJpg1uJMdlyGdCnwE=
+github.com/go-estoria/estoria v0.8.0/go.mod h1:w/1pwY/YU9M4WV+HdL2vpYVAhVINFwaVf1nSPnebNJQ=
+github.com/go-estoria/estoria-contrib v0.8.0 h1:iPI9jKLpjodrcTk4Tr1YEakw0b1S5PC6BbwoNtBml/g=
+github.com/go-estoria/estoria-contrib v0.8.0/go.mod h1:buwC8y+PbBsffvosOe00D2h5pGqaX0RqTNVr+aTGrDQ=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=

--- a/inspector/server_test.go
+++ b/inspector/server_test.go
@@ -238,7 +238,7 @@ func seedTestStore(t *testing.T, dir string) string {
 
 	appendEvents := func(streamID typeid.ID, events ...*eventstore.WritableEvent) {
 		t.Helper()
-		if err := store.AppendStream(ctx, streamID, events, eventstore.AppendStreamOptions{}); err != nil {
+		if _, err := store.AppendStream(ctx, streamID, events, eventstore.AppendStreamOptions{}); err != nil {
 			t.Fatalf("appending to %s: %v", streamID, err)
 		}
 	}

--- a/kanban/demo_test.go
+++ b/kanban/demo_test.go
@@ -54,9 +54,14 @@ func newTestServer(t *testing.T) *server {
 		t.Fatal(err)
 	}
 
+	snapStore, err := streamsnapshots.New(eventStore)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	snapshotting, err := aggregatestore.NewSnapshottingStore(
 		eventSourced,
-		streamsnapshots.New(eventStore),
+		snapStore,
 		snapshotstore.EventCountSnapshotPolicy{N: 10},
 	)
 	if err != nil {

--- a/kanban/go.mod
+++ b/kanban/go.mod
@@ -3,8 +3,8 @@ module github.com/go-estoria/estoria-examples/kanban
 go 1.26.2
 
 require (
-	github.com/go-estoria/estoria v0.7.0
-	github.com/go-estoria/estoria-contrib v0.7.0
+	github.com/go-estoria/estoria v0.8.0
+	github.com/go-estoria/estoria-contrib v0.8.0
 	github.com/gofrs/uuid/v5 v5.4.0
 	golang.org/x/time v0.15.0
 	modernc.org/sqlite v1.54.0

--- a/kanban/go.sum
+++ b/kanban/go.sum
@@ -1,9 +1,9 @@
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/go-estoria/estoria v0.7.0 h1:6VZjt2oWbvmLm55DSJPpGcaDyrLGXE9iP6uRvXfOIb0=
-github.com/go-estoria/estoria v0.7.0/go.mod h1:w/1pwY/YU9M4WV+HdL2vpYVAhVINFwaVf1nSPnebNJQ=
-github.com/go-estoria/estoria-contrib v0.7.0 h1:nlvMUNXmP9mhJCcs5kbK90n3wkGkyF6VlKG4ljNDiQY=
-github.com/go-estoria/estoria-contrib v0.7.0/go.mod h1:ZKek1dXoVAPJlcSh2kjYm0bPy1F7LBxtchQ63g4XJJQ=
+github.com/go-estoria/estoria v0.8.0 h1:vEadMNigE+stOQsvWBEpk/JdFgiJpg1uJMdlyGdCnwE=
+github.com/go-estoria/estoria v0.8.0/go.mod h1:w/1pwY/YU9M4WV+HdL2vpYVAhVINFwaVf1nSPnebNJQ=
+github.com/go-estoria/estoria-contrib v0.8.0 h1:iPI9jKLpjodrcTk4Tr1YEakw0b1S5PC6BbwoNtBml/g=
+github.com/go-estoria/estoria-contrib v0.8.0/go.mod h1:buwC8y+PbBsffvosOe00D2h5pGqaX0RqTNVr+aTGrDQ=
 github.com/gofrs/uuid/v5 v5.4.0 h1:EfbpCTjqMuGyq5ZJwxqzn3Cbr2d0rUZU7v5ycAk/e/0=
 github.com/gofrs/uuid/v5 v5.4.0/go.mod h1:CDOjlDMVAtN56jqyRUZh58JT31Tiw7/oQyEXZV+9bD8=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=

--- a/kanban/main.go
+++ b/kanban/main.go
@@ -158,9 +158,14 @@ func run(ctx context.Context, addr, dbPath string, snapshotEvery int64, demo dem
 	//    start from the latest snapshot instead of replaying from scratch.
 	//    Snapshots are stored as events in a parallel "boardsnapshot" stream
 	//    in the same SQLite database — no separate snapshot storage needed.
+	snapStore, err := streamsnapshots.New(eventStore)
+	if err != nil {
+		return fmt.Errorf("creating snapshot store: %w", err)
+	}
+
 	snapshotting, err := aggregatestore.NewSnapshottingStore(
 		eventSourced,
-		streamsnapshots.New(eventStore),
+		snapStore,
 		snapshotstore.EventCountSnapshotPolicy{N: snapshotEvery},
 	)
 	if err != nil {

--- a/kurrent/go.mod
+++ b/kurrent/go.mod
@@ -3,8 +3,8 @@ module github.com/go-estoria/estoria-examples/kurrent
 go 1.26.2
 
 require (
-	github.com/go-estoria/estoria v0.7.0
-	github.com/go-estoria/estoria-contrib v0.7.0
+	github.com/go-estoria/estoria v0.8.0
+	github.com/go-estoria/estoria-contrib v0.8.0
 	github.com/gofrs/uuid/v5 v5.4.0
 	github.com/kurrent-io/KurrentDB-Client-Go v1.4.1
 )

--- a/kurrent/go.sum
+++ b/kurrent/go.sum
@@ -30,10 +30,10 @@ github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/
 github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/go-estoria/estoria v0.7.0 h1:6VZjt2oWbvmLm55DSJPpGcaDyrLGXE9iP6uRvXfOIb0=
-github.com/go-estoria/estoria v0.7.0/go.mod h1:w/1pwY/YU9M4WV+HdL2vpYVAhVINFwaVf1nSPnebNJQ=
-github.com/go-estoria/estoria-contrib v0.7.0 h1:nlvMUNXmP9mhJCcs5kbK90n3wkGkyF6VlKG4ljNDiQY=
-github.com/go-estoria/estoria-contrib v0.7.0/go.mod h1:ZKek1dXoVAPJlcSh2kjYm0bPy1F7LBxtchQ63g4XJJQ=
+github.com/go-estoria/estoria v0.8.0 h1:vEadMNigE+stOQsvWBEpk/JdFgiJpg1uJMdlyGdCnwE=
+github.com/go-estoria/estoria v0.8.0/go.mod h1:w/1pwY/YU9M4WV+HdL2vpYVAhVINFwaVf1nSPnebNJQ=
+github.com/go-estoria/estoria-contrib v0.8.0 h1:iPI9jKLpjodrcTk4Tr1YEakw0b1S5PC6BbwoNtBml/g=
+github.com/go-estoria/estoria-contrib v0.8.0/go.mod h1:buwC8y+PbBsffvosOe00D2h5pGqaX0RqTNVr+aTGrDQ=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=

--- a/mongodb/go.mod
+++ b/mongodb/go.mod
@@ -3,8 +3,8 @@ module github.com/go-estoria/estoria-examples/mongodb
 go 1.26.2
 
 require (
-	github.com/go-estoria/estoria v0.7.0
-	github.com/go-estoria/estoria-contrib v0.7.0
+	github.com/go-estoria/estoria v0.8.0
+	github.com/go-estoria/estoria-contrib v0.8.0
 	github.com/gofrs/uuid/v5 v5.4.0
 	go.mongodb.org/mongo-driver/v2 v2.8.0
 )

--- a/mongodb/go.sum
+++ b/mongodb/go.sum
@@ -30,10 +30,10 @@ github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/
 github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/go-estoria/estoria v0.7.0 h1:6VZjt2oWbvmLm55DSJPpGcaDyrLGXE9iP6uRvXfOIb0=
-github.com/go-estoria/estoria v0.7.0/go.mod h1:w/1pwY/YU9M4WV+HdL2vpYVAhVINFwaVf1nSPnebNJQ=
-github.com/go-estoria/estoria-contrib v0.7.0 h1:nlvMUNXmP9mhJCcs5kbK90n3wkGkyF6VlKG4ljNDiQY=
-github.com/go-estoria/estoria-contrib v0.7.0/go.mod h1:ZKek1dXoVAPJlcSh2kjYm0bPy1F7LBxtchQ63g4XJJQ=
+github.com/go-estoria/estoria v0.8.0 h1:vEadMNigE+stOQsvWBEpk/JdFgiJpg1uJMdlyGdCnwE=
+github.com/go-estoria/estoria v0.8.0/go.mod h1:w/1pwY/YU9M4WV+HdL2vpYVAhVINFwaVf1nSPnebNJQ=
+github.com/go-estoria/estoria-contrib v0.8.0 h1:iPI9jKLpjodrcTk4Tr1YEakw0b1S5PC6BbwoNtBml/g=
+github.com/go-estoria/estoria-contrib v0.8.0/go.mod h1:buwC8y+PbBsffvosOe00D2h5pGqaX0RqTNVr+aTGrDQ=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=

--- a/opentelemetry/go.mod
+++ b/opentelemetry/go.mod
@@ -3,8 +3,8 @@ module github.com/go-estoria/estoria-examples/telemetry
 go 1.26.2
 
 require (
-	github.com/go-estoria/estoria v0.7.0
-	github.com/go-estoria/estoria-contrib v0.7.0
+	github.com/go-estoria/estoria v0.8.0
+	github.com/go-estoria/estoria-contrib v0.8.0
 	github.com/gofrs/uuid/v5 v5.4.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.33.0

--- a/opentelemetry/go.sum
+++ b/opentelemetry/go.sum
@@ -4,10 +4,10 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/go-estoria/estoria v0.7.0 h1:6VZjt2oWbvmLm55DSJPpGcaDyrLGXE9iP6uRvXfOIb0=
-github.com/go-estoria/estoria v0.7.0/go.mod h1:w/1pwY/YU9M4WV+HdL2vpYVAhVINFwaVf1nSPnebNJQ=
-github.com/go-estoria/estoria-contrib v0.7.0 h1:nlvMUNXmP9mhJCcs5kbK90n3wkGkyF6VlKG4ljNDiQY=
-github.com/go-estoria/estoria-contrib v0.7.0/go.mod h1:ZKek1dXoVAPJlcSh2kjYm0bPy1F7LBxtchQ63g4XJJQ=
+github.com/go-estoria/estoria v0.8.0 h1:vEadMNigE+stOQsvWBEpk/JdFgiJpg1uJMdlyGdCnwE=
+github.com/go-estoria/estoria v0.8.0/go.mod h1:w/1pwY/YU9M4WV+HdL2vpYVAhVINFwaVf1nSPnebNJQ=
+github.com/go-estoria/estoria-contrib v0.8.0 h1:iPI9jKLpjodrcTk4Tr1YEakw0b1S5PC6BbwoNtBml/g=
+github.com/go-estoria/estoria-contrib v0.8.0/go.mod h1:buwC8y+PbBsffvosOe00D2h5pGqaX0RqTNVr+aTGrDQ=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/orders/go.mod
+++ b/orders/go.mod
@@ -3,8 +3,8 @@ module github.com/go-estoria/estoria-examples/orders
 go 1.26.2
 
 require (
-	github.com/go-estoria/estoria v0.7.0
-	github.com/go-estoria/estoria-contrib v0.7.0
+	github.com/go-estoria/estoria v0.8.0
+	github.com/go-estoria/estoria-contrib v0.8.0
 	github.com/gofrs/uuid/v5 v5.4.0
 	github.com/jackc/pgx/v5 v5.10.0
 	golang.org/x/time v0.15.0

--- a/orders/go.sum
+++ b/orders/go.sum
@@ -31,10 +31,10 @@ github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/
 github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/go-estoria/estoria v0.7.0 h1:6VZjt2oWbvmLm55DSJPpGcaDyrLGXE9iP6uRvXfOIb0=
-github.com/go-estoria/estoria v0.7.0/go.mod h1:w/1pwY/YU9M4WV+HdL2vpYVAhVINFwaVf1nSPnebNJQ=
-github.com/go-estoria/estoria-contrib v0.7.0 h1:nlvMUNXmP9mhJCcs5kbK90n3wkGkyF6VlKG4ljNDiQY=
-github.com/go-estoria/estoria-contrib v0.7.0/go.mod h1:ZKek1dXoVAPJlcSh2kjYm0bPy1F7LBxtchQ63g4XJJQ=
+github.com/go-estoria/estoria v0.8.0 h1:vEadMNigE+stOQsvWBEpk/JdFgiJpg1uJMdlyGdCnwE=
+github.com/go-estoria/estoria v0.8.0/go.mod h1:w/1pwY/YU9M4WV+HdL2vpYVAhVINFwaVf1nSPnebNJQ=
+github.com/go-estoria/estoria-contrib v0.8.0 h1:iPI9jKLpjodrcTk4Tr1YEakw0b1S5PC6BbwoNtBml/g=
+github.com/go-estoria/estoria-contrib v0.8.0/go.mod h1:buwC8y+PbBsffvosOe00D2h5pGqaX0RqTNVr+aTGrDQ=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=

--- a/postgres/go.mod
+++ b/postgres/go.mod
@@ -3,8 +3,8 @@ module github.com/go-estoria/estoria-examples/postgres
 go 1.26.2
 
 require (
-	github.com/go-estoria/estoria v0.7.0
-	github.com/go-estoria/estoria-contrib v0.7.0
+	github.com/go-estoria/estoria v0.8.0
+	github.com/go-estoria/estoria-contrib v0.8.0
 	github.com/gofrs/uuid/v5 v5.4.0
 	github.com/jackc/pgx/v5 v5.10.0
 )

--- a/postgres/go.sum
+++ b/postgres/go.sum
@@ -31,10 +31,10 @@ github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/
 github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/go-estoria/estoria v0.7.0 h1:6VZjt2oWbvmLm55DSJPpGcaDyrLGXE9iP6uRvXfOIb0=
-github.com/go-estoria/estoria v0.7.0/go.mod h1:w/1pwY/YU9M4WV+HdL2vpYVAhVINFwaVf1nSPnebNJQ=
-github.com/go-estoria/estoria-contrib v0.7.0 h1:nlvMUNXmP9mhJCcs5kbK90n3wkGkyF6VlKG4ljNDiQY=
-github.com/go-estoria/estoria-contrib v0.7.0/go.mod h1:ZKek1dXoVAPJlcSh2kjYm0bPy1F7LBxtchQ63g4XJJQ=
+github.com/go-estoria/estoria v0.8.0 h1:vEadMNigE+stOQsvWBEpk/JdFgiJpg1uJMdlyGdCnwE=
+github.com/go-estoria/estoria v0.8.0/go.mod h1:w/1pwY/YU9M4WV+HdL2vpYVAhVINFwaVf1nSPnebNJQ=
+github.com/go-estoria/estoria-contrib v0.8.0 h1:iPI9jKLpjodrcTk4Tr1YEakw0b1S5PC6BbwoNtBml/g=
+github.com/go-estoria/estoria-contrib v0.8.0/go.mod h1:buwC8y+PbBsffvosOe00D2h5pGqaX0RqTNVr+aTGrDQ=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=


### PR DESCRIPTION
Updates all nine example modules to estoria v0.8.0 and estoria-contrib v0.8.0.

The event-stream snapshot store constructor now takes options and returns an error; the `streamsnapshots.New` call sites in kanban and fleet adopt the new signature, and the inspector's test helper adopts `AppendStream`'s two-valued return. No other code changes were needed.
